### PR TITLE
Add Auto Memory

### DIFF
--- a/BrainfuckInterceptor/App.xaml.cs
+++ b/BrainfuckInterceptor/App.xaml.cs
@@ -19,7 +19,7 @@ namespace BrainfuckInterceptor {
 				BrainfuckInterceptor.Properties.Settings.Default.theme = "Dark";
 
 			if(BrainfuckInterceptor.Properties.Settings.Default.memory == "")
-				BrainfuckInterceptor.Properties.Settings.Default.memory = "ExtendedASCII";
+				BrainfuckInterceptor.Properties.Settings.Default.memory = "Auto";
 
 			switch(BrainfuckInterceptor.Properties.Settings.Default.theme.ToLower()) {
 				case "light": {

--- a/BrainfuckInterceptor/BrainfuckInterceptor.csproj
+++ b/BrainfuckInterceptor/BrainfuckInterceptor.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
 	<OutputType>WinExe</OutputType>
 	<TargetFramework>net6.0-windows</TargetFramework>
-	<AssemblyVersion>2.3.0</AssemblyVersion>
-	<FileVersion>2.3.0</FileVersion>
-	<InformationalVersion>2.3.0</InformationalVersion>
+	<AssemblyVersion>2.4.0</AssemblyVersion>
+	<FileVersion>2.4.0</FileVersion>
+	<InformationalVersion>2.4.0</InformationalVersion>
 	<NeutralLanguage>en</NeutralLanguage>
 	<PackageTags>brainfuck, extended ascii, converter, interpreter</PackageTags>
 	<RepositoryType>git</RepositoryType>

--- a/BrainfuckInterceptor/Scripts/Memory/MemoryAuto.cs
+++ b/BrainfuckInterceptor/Scripts/Memory/MemoryAuto.cs
@@ -7,7 +7,7 @@ namespace BrainfuckInterceptor.Scripts.Memory {
 		private readonly MemoryLettersNumbers lettersNumbers = new();
 
 		public override string Encode(string inputText) {
-			if(Regex.IsMatch(inputText, @"^[a-zA-Z0-9.,]+$"))
+			if(Regex.IsMatch(inputText, @"^[a-zA-Z0-9., ]+$"))
 				return lettersNumbers.Encode(inputText);
 			
 			if(Regex.IsMatch(inputText, @"^[\x00-\x7F]+$"))

--- a/BrainfuckInterceptor/Scripts/Memory/MemoryAuto.cs
+++ b/BrainfuckInterceptor/Scripts/Memory/MemoryAuto.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.RegularExpressions;
+
+namespace BrainfuckInterceptor.Scripts.Memory {
+	internal class MemoryAuto:Memory {
+		private readonly MemoryExtendedASCII extendedASCII = new();
+		private readonly MemoryASCII ascii = new();
+		private readonly MemoryLettersNumbers lettersNumbers = new();
+
+		public override string Encode(string inputText) {
+			if(Regex.IsMatch(inputText, @"^[a-zA-Z0-9.,]+$"))
+				return lettersNumbers.Encode(inputText);
+			
+			if(Regex.IsMatch(inputText, @"^[\x00-\x7F]+$"))
+				return ascii.Encode(inputText);
+
+			return extendedASCII.Encode(inputText);
+		}
+	}
+}

--- a/BrainfuckInterceptor/Scripts/Memory/MemoryHandler.cs
+++ b/BrainfuckInterceptor/Scripts/Memory/MemoryHandler.cs
@@ -6,6 +6,7 @@ namespace BrainfuckInterceptor.Scripts.Memory {
 		private readonly MemoryASCII ascii = new();
 		private readonly MemoryLettersNumbers lettersNumbers = new();
 		private readonly MemoryEmpty empty = new();
+		private readonly MemoryAuto auto = new();
 
 		public string Encode(string inputText) {
 			return Properties.Settings.Default.memory.ToLower() switch {
@@ -13,19 +14,9 @@ namespace BrainfuckInterceptor.Scripts.Memory {
 				"ascii" => ascii.Encode(inputText),
 				"lettersnumbers" => lettersNumbers.Encode(inputText),
 				"empty" => empty.Encode(inputText),
+				"auto" => auto.Encode(inputText),
 				_ => throw new NotSupportedException($"The set Memory type '{Properties.Settings.Default.memory}' is invalid. Choose a valid one in the settings panel.")
 			};
 		}
-
-		/* TODO:
-		 * Add the check from settings which memory should be used
-		 * Create that object with the correct class
-		 * 
-		 * Add Encode class that uses the correct memory
-		 * Should just have one "memory" object that is different dependent on the setting if possible,
-		 * in order to make just one encode method for everything
-		 * 
-		 * For the future, there will be an auto memory that uses the best possible for the input
-		 */
 	}
 }

--- a/BrainfuckInterceptor/Scripts/Memory/MemoryLettersNumbers.cs
+++ b/BrainfuckInterceptor/Scripts/Memory/MemoryLettersNumbers.cs
@@ -13,7 +13,7 @@
 					output += GetCode(inputChar, 2);
 				else if(inputChar >= 97 && inputChar <= 122)
 					output += GetCode(inputChar, 3);
-				else if(inputChar >= 48 && inputChar <= 57)
+				else if(inputChar >= 44 && inputChar <= 57)
 					output += GetCode(inputChar, 1);
 				else
 					output += GetCode(inputChar, 0);

--- a/BrainfuckInterceptor/Views/SettingsUI.xaml
+++ b/BrainfuckInterceptor/Views/SettingsUI.xaml
@@ -18,6 +18,7 @@
 			<RadioButton x:Name="MemoryExtendedASCIIButton" Content="Extended ASCII" Margin="5" Click="MemoryExtendedASCIIButton_Click"/>
 			<RadioButton x:Name="MemoryLettersNumbersButton" Content="Only Letters and Numbers" Margin="5" Click="MemoryLettersNumbersButton_Click"/>
 			<RadioButton x:Name="MemoryEmptyButton" Content="Empty" Margin="5" Click="MemoryEmptyButton_Click"/>
+			<RadioButton x:Name="MemoryAutoButton" Content="Auto" Margin="5" Click="MemoryAutoButton_Click"/>
 		</WrapPanel>
 	</StackPanel>
 </Page>

--- a/BrainfuckInterceptor/Views/SettingsUI.xaml.cs
+++ b/BrainfuckInterceptor/Views/SettingsUI.xaml.cs
@@ -26,6 +26,10 @@ namespace BrainfuckInterceptor.Views {
 					MemoryEmptyButton.IsChecked = true;
 					break;
 				}
+				case "auto": {
+					MemoryAutoButton.IsChecked = true;
+					break;
+				}
 			}
 
 			switch(Properties.Settings.Default.theme.ToLower()) {

--- a/BrainfuckInterceptor/Views/SettingsUI.xaml.cs
+++ b/BrainfuckInterceptor/Views/SettingsUI.xaml.cs
@@ -68,5 +68,8 @@ namespace BrainfuckInterceptor.Views {
 		private void MemoryEmptyButton_Click(object sender, RoutedEventArgs e) {
 			Properties.Settings.Default.memory = "Empty";
 		}
+		private void MemoryAutoButton_Click(object sender, RoutedEventArgs e) {
+			Properties.Settings.Default.memory = "Auto";
+		}
 	}
 }


### PR DESCRIPTION
Add a new Auto memory option that can choose between normal ASCII, Extended ASCII or LettersNumbers Memory depending on the input.

Also updated so LettersNumbers memory cell for numbers goes all the way down to 44 (previously 48) in order to include `,.-/` in that cell as well to minimize the BRAINFUCK output length. 